### PR TITLE
Deleted somelines.

### DIFF
--- a/src/nutritionAPIV2_controllers/FrameController.java
+++ b/src/nutritionAPIV2_controllers/FrameController.java
@@ -42,24 +42,10 @@ public class FrameController extends AnchorPane implements Initializable
 	
 	/* TopPanel Variables */
 	
-	@FXML
-	FrameTopController frameTopController;
-	
-	@FXML
-	FrameBottomLeftController frameBottomLeftController;
-	
-	@FXML
-	FrameBottomRightController frameBottomRightController;
-	
 	public static FrameController controller;
-
     
 	public FrameController()
 	{
-		frameTopController = new FrameTopController();
-		frameBottomLeftController = new FrameBottomLeftController();
-		frameBottomRightController = new FrameBottomRightController();
-		
 		FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("/nutritionAPIV2_view/Frame.fxml"));
 		fxmlLoader.setRoot(this);
 		fxmlLoader.setController(this);


### PR DESCRIPTION
We don't need those instantiations since FXMLLoader is already instantiating those components when they are tagged in the FXML files.

Example: "<FrameTopController />".
